### PR TITLE
test-new-package-label: init at 0.0.1

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -99,16 +99,13 @@ runs:
               break
           }
 
-          // Create all worktrees in parallel.
-          await Promise.all(
-            commits
-              .filter(({ path }) => Boolean(path))
-              .map(async ({ sha, path }) => {
-                await run('git', 'worktree', 'add', join('nixpkgs', path), sha, '--no-checkout')
-                await run('git', '-C', join('nixpkgs', path), 'sparse-checkout', 'disable')
-                await run('git', '-C', join('nixpkgs', path), 'checkout', '--progress')
-              })
-          )
+          // Create worktrees sequentially to avoid git lock conflicts.
+          // Parallel worktree creation can fail with "failed to read .git/worktrees/.../commondir".
+          for (const { sha, path } of commits.filter(({ path }) => Boolean(path))) {
+            await run('git', 'worktree', 'add', join('nixpkgs', path), sha, '--no-checkout')
+            await run('git', '-C', join('nixpkgs', path), 'sparse-checkout', 'disable')
+            await run('git', '-C', join('nixpkgs', path), 'checkout', '--progress')
+          }
 
           // Apply pin bump to untrusted worktree
           if (pin_bump_sha) {

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -97,7 +97,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           !contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || github.token }}
           configuration-path: .github/labeler.yml # default
           sync-labels: true
 
@@ -107,7 +107,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           !contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || github.token }}
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
 
@@ -120,7 +120,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || github.token }}
           configuration-path: .github/labeler-development-branches.yml
           sync-labels: true
 

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -121,6 +121,11 @@ module.exports = async ({ github, context, core, dry }) => {
       return []
     }
 
+    // Forks don't have NixOS teams, return empty list
+    if (isFork) {
+      return []
+    }
+
     if (!members[team_slug]) {
       members[team_slug] = github.paginate(github.rest.teams.listMembersInOrg, {
         org: context.repo.owner,

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -321,9 +321,27 @@ module.exports = async ({ github, context, core, dry }) => {
         expectedHash: artifact.digest,
       })
 
-      const evalLabels = JSON.parse(
+      const changedPaths = JSON.parse(
         await readFile(`${pull_number}/changed-paths.json`, 'utf-8'),
-      ).labels
+      )
+      const evalLabels = changedPaths.labels
+
+      // Fetch all PR commits to check their messages for package patterns
+      const prCommits = await github.paginate(github.rest.pulls.listCommits, {
+        ...context.repo,
+        pull_number,
+        per_page: 100,
+      })
+      const commitMessages = prCommits.map((c) => c.commit.message)
+
+      // Label new package PRs: "packagename: init at X.Y.Z"
+      const newPackagePattern = /: init at\b/
+      const hasNewPackages = changedPaths.attrdiff?.added?.length > 0
+      const commitsIndicateNewPackage = commitMessages.some((msg) =>
+        newPackagePattern.test(msg),
+      )
+      evalLabels['8.has: package (new)'] =
+        hasNewPackages && commitsIndicateNewPackage
 
       // TODO: Get "changed packages" information from list of changed by-name files
       // in addition to just the Eval results, to make this work for these packages

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -343,6 +343,14 @@ module.exports = async ({ github, context, core, dry }) => {
       evalLabels['8.has: package (new)'] =
         hasNewPackages && commitsIndicateNewPackage
 
+      // Label package update PRs: "packagename: X.Y.Z -> A.B.C"
+      // Matches versions like: 1.2.3, 0-unstable-2024-01-15, 1.3rc1, alpha, unstable
+      const updatePackagePattern = /: [\w.-]+ -> [\w.-]+/
+      const commitsIndicateUpdate = commitMessages.some((msg) =>
+        updatePackagePattern.test(msg),
+      )
+      evalLabels['8.has: package (update)'] = commitsIndicateUpdate
+
       // TODO: Get "changed packages" information from list of changed by-name files
       // in addition to just the Eval results, to make this work for these packages
       // when Eval results have expired as well.

--- a/pkgs/by-name/te/test-new-package-label/package.nix
+++ b/pkgs/by-name/te/test-new-package-label/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  pname = "test-new-package-label";
+  version = "0.0.1";
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    echo "#!/bin/sh" > $out/bin/test-new-package-label
+    echo "echo hello" >> $out/bin/test-new-package-label
+    chmod +x $out/bin/test-new-package-label
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Test package for CI label automation";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Test PR to verify the new package labeling automation.

This PR tests that:
1. When a PR adds a new package (detected via eval)
2. AND the PR title contains `: init at`
3. The label `8.has: package (new)` is automatically applied

This includes the CI change from `test/new-package-label` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new package to the system for testing purposes. The package provides a command-line executable that users can invoke directly from their terminal. It is MIT licensed and compatible with all supported platforms. The package includes automated installation procedures and is ready for immediate use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->