### PR TITLE
nixos/shadow: use su from sudo-rs when enabled

### DIFF
--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -262,7 +262,12 @@ in
           };
         in
         {
-          su = mkSetuidRoot "${cfg.package.su}/bin/su";
+          su = mkSetuidRoot (
+            if config.security.sudo-rs.enable then
+              "${config.security.sudo-rs.package}/bin/su"
+            else
+              "${cfg.package.su}/bin/su"
+          );
           sg = mkSetuidRoot "${cfg.package.out}/bin/sg";
           newgrp = mkSetuidRoot "${cfg.package.out}/bin/newgrp";
           newuidmap = mkSetuidRoot "${cfg.package.out}/bin/newuidmap";


### PR DESCRIPTION
When `security.sudo-rs.enable` is `true`, the `su` setuid wrapper now uses the memory-safe `su` implementation from `sudo-rs` instead of the one from the `shadow` package.

Users who opt into `sudo-rs` likely want the full benefit of its memory-safe tooling, including `su`.

### Changes

- `nixos/modules/programs/shadow.nix`: Conditionally set the `su` wrapper source to `sudo-rs`'s `su` binary when `security.sudo-rs.enable` is `true`.

### Testing

Verified with `nix-instantiate --eval`:
- `sudo-rs.enable = true` → `su` source resolves to `.../sudo-rs-0.2.12/bin/su`
- `sudo-rs.enable = false` → `su` source resolves to `.../shadow-4.19.3-su/bin/su`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `su` command to use the correct binary when sudo-rs is enabled in system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->