### PR TITLE
test: trigger eligibility check workflow

### DIFF
--- a/ci/github-script/README.md
+++ b/ci/github-script/README.md
@@ -10,7 +10,7 @@ To run any of the scripts locally:
 
 ## Check commits
 
-Run `./run commits OWNER REPO PR`, where OWNER is your username or "NixOS", REPO is the name of your fork or "nixpkgs" and PR is the number of the pull request to check.
+Run `./run commits OWNER REPO PR`, where OWNER is your username or "NixOS", REPO is the name of your fork or "nixpkgs", and PR is the number of the pull request to check.
 
 ## Labeler
 


### PR DESCRIPTION
Tiny no-op PR to exercise the new `merge-bot eligibility` check run end-to-end in this fork.

Expected: the workflow runs, the bot job creates a check named **merge-bot eligibility** on the head SHA with conclusion `neutral` and a checklist showing why this PR is not eligible (only by-name PRs are).